### PR TITLE
Allow serverspec tests per template

### DIFF
--- a/bin/test-box-vcloud.bat
+++ b/bin/test-box-vcloud.bat
@@ -145,7 +145,7 @@ echo       vcloud.catalog_name = "%vcloud_catalog%" >>Vagrantfile
 echo       override.vm.usable_port_range = 2200..2999 >>Vagrantfile
 echo     end >>Vagrantfile
 echo     tst.vm.provision :serverspec do ^|spec^| >>Vagrantfile
-echo       spec.pattern = '../test/*_%spec%.rb' >>Vagrantfile
+echo       spec.pattern = '../test/{*_%spec%.rb,%boxname%.rb}' >>Vagrantfile
 echo     end >>Vagrantfile
 echo   end >>Vagrantfile
 echo end >>Vagrantfile

--- a/bin/test-box-virtualbox.bat
+++ b/bin/test-box-virtualbox.bat
@@ -94,7 +94,7 @@ echo   config.vm.define :"tst" do ^|tst^| >>Vagrantfile
 echo     tst.vm.box = "%boxname%" >>Vagrantfile
 echo     tst.vm.hostname = "tst"
 echo     tst.vm.provision :serverspec do ^|spec^| >>Vagrantfile
-echo       spec.pattern = '../test/*_%spec%.rb' >>Vagrantfile
+echo       spec.pattern = '../test/{*_%spec%.rb,%boxname%.rb}' >>Vagrantfile
 echo     end >>Vagrantfile
 echo   end >>Vagrantfile
 echo end >>Vagrantfile

--- a/bin/test-box-vmware.bat
+++ b/bin/test-box-vmware.bat
@@ -103,7 +103,7 @@ echo   config.vm.define :"tst" do ^|tst^| >>Vagrantfile
 echo     tst.vm.box = "%boxname%" >>Vagrantfile
 echo     tst.vm.hostname = "tst"
 echo     tst.vm.provision :serverspec do ^|spec^| >>Vagrantfile
-echo       spec.pattern = '../test/*_%spec%.rb' >>Vagrantfile
+echo       spec.pattern = '../test/{*_%spec%.rb,%boxname%.rb}' >>Vagrantfile
 echo     end >>Vagrantfile
 echo   end >>Vagrantfile
 echo end >>Vagrantfile

--- a/test/windows_2016_docker.rb
+++ b/test/windows_2016_docker.rb
@@ -1,0 +1,28 @@
+describe 'windows_2016_docker' do
+  describe command('& docker version') do
+    its(:stdout) { should match /Client:. Version:      1.12.2-cs2-ws-beta-rc1. API version:  1.25/m }
+    its(:stdout) { should match /Server:. Version:      1.12.2-cs2-ws-beta-rc1. API version:  1.25/m }
+    its(:exit_status) { should eq 0 }
+  end
+
+  describe 'Docker service' do
+    describe service('docker') do
+      it { should be_installed  }
+      it { should be_enabled  }
+      it { should be_running  }
+      it { should have_start_mode("Automatic")  }
+    end
+    describe port(2375) do
+      it { should be_listening  }
+    end
+  end
+
+  describe 'Docker images' do
+    describe docker_image('microsoft/windowsservercore:latest') do
+      it { should exist }
+    end
+    describe docker_image('microsoft/windowsservercore:10.0.14393.206') do
+      it { should exist }
+    end
+  end
+end


### PR DESCRIPTION
Allow an optional serverspec test file per Packer template.
Introducing some tests for the `windows_2016_docker` Packer template, there now is a `test/windows_2016_docker.rb` file with serverspec tests.
